### PR TITLE
Fix jdk8u292 b04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@
 # macos desktop files
 .DS_Store
 
+# Emacs
+*~
+.#*
+

--- a/build8.sh
+++ b/build8.sh
@@ -167,8 +167,10 @@ patch_macos_jdkquality() {
 	# fix concurrency crash; this patch is now in the JDK
 	#  applypatch hotspot "$PATCH_DIR/jdk8u-hotspot-8181872.patch"
 	# these patches mitigate a clang issue by avoding intrinsic strncat()
-	applypatch hotspot "$PATCH_DIR/jdk8u-hotspot-01-8062370.patch"
-	applypatch hotspot "$PATCH_DIR/jdk8u-hotspot-02-8060721.patch"
+
+	###### already in upstream jdk
+	###### applypatch hotspot "$PATCH_DIR/jdk8u-hotspot-01-8062370.patch"
+	###### applypatch hotspot "$PATCH_DIR/jdk8u-hotspot-02-8060721.patch"
 	# disable optimization on some files when using clang 
 	# (should check if this is still tha case on newer clang)
 	applypatch hotspot "$PATCH_DIR/jdk8u-hotspot-8138820.patch"
@@ -319,7 +321,7 @@ downloadjdksrc
 print_jdk_repo_id
 cleanjdk
 revertjdk
-patchjdk
+patch_jdk
 configurejdk
 buildjdk
 

--- a/build8.sh
+++ b/build8.sh
@@ -246,7 +246,7 @@ configurejdk() {
 		DARWIN_CONFIG="--with-toolchain-type=clang \
             --with-xcode-path="$XCODE_APP" \
             --includedir="$XCODE_DEVELOPER_PREFIX/Toolchains/XcodeDefault.xctoolchain/usr/include" \
-            --with-boot-jdk="$BOOT_JDK""
+            --with-boot-jdk="$BOOT_JDK" --with-native-debug-symbols="none""
 	fi
     if $BUILD_JAVAFX ; then
         # the javafx build requires 1.8.0-b40 or higher


### PR DESCRIPTION
Simon,

thanks for providing this immensely helpful repo. We're stuck with JDK 8 for the time being and I needed to compile it myself for macOS.

I hit some road blocks when compiling JDK8u292 with your repo. Please consider the changes in this pull request. It worked with those, but I'm not entirely sure whether the disabling of debug symbols is entirely desirable.
